### PR TITLE
ObjectToString equals initial commandString

### DIFF
--- a/src/Barberry/Plugin/Imagemagic/Command.php
+++ b/src/Barberry/Plugin/Imagemagic/Command.php
@@ -21,8 +21,8 @@ class Command implements InterfaceCommand
         $params = explode("_", $commandString);
         foreach ($params as $val) {
             if (preg_match("@^([\d]*)x([\d]*)$@", $val, $regs)) {
-                $this->width = strlen($regs[1]) ? min((int)$regs[1], self::MAX_WIDTH) : null;
-                $this->height = strlen($regs[2]) ? min((int)$regs[2], self::MAX_HEIGHT) : null;
+                $this->width = strlen($regs[1]) ? (int)$regs[1] : null;
+                $this->height = strlen($regs[2]) ? (int)$regs[2] : null;
             }
         }
         return $this;
@@ -35,12 +35,12 @@ class Command implements InterfaceCommand
 
     public function width()
     {
-        return $this->width;
+        return min($this->width, self::MAX_WIDTH);
     }
 
     public function height()
     {
-        return $this->height;
+        return min($this->height, self::MAX_HEIGHT);
     }
 
     public function __toString()

--- a/test/CommandTest.php
+++ b/test/CommandTest.php
@@ -38,6 +38,19 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(self::command('')->conforms(''));
     }
 
+    public function testReplaceInitialSizesIntoMaxAndMin()
+    {
+        $command = self::command('9000x9000');
+        $this->assertEquals(800, $command->width());
+        $this->assertEquals(600, $command->height());
+    }
+
+    public function testInitialCommandStringEqualsObjectToStringConvertion()
+    {
+        $command = self::command('9000x9000');
+        $this->assertSame(strval($command),'9000x9000');
+    }
+
 //--------------------------------------------------------------------------------------------------
 
     private static function command($commandString = null)


### PR DESCRIPTION
ObjectToString equals initial commandString
But functions width() height() returns MinMax values + tests
