### PR TITLE
Avoid a way when clients need generate helpless `x`

### DIFF
--- a/src/Barberry/Plugin/Imagemagick/Command.php
+++ b/src/Barberry/Plugin/Imagemagick/Command.php
@@ -46,7 +46,7 @@ class Command implements InterfaceCommand
             if (preg_match("@colorspace(Gray|CMYK|sRGB|Transparent|RGB)@", $val, $regs)) {
                 $this->colorspace = strlen($regs[1]) ? $regs[1] : null;
             }
-            if (preg_match("@trim((?:[0-F]{3,6})?)x((?:\d{1,2})?)@", $val, $regs)) {
+            if (preg_match("@trim((?:[0-F]{3,6})?)x?((?:\d{1,2})?)@", $val, $regs)) {
                 $this->trimColor = $regs[1];
                 $this->trimFuzz = $regs[2];
             }
@@ -134,11 +134,18 @@ class Command implements InterfaceCommand
             $str .= 'colorspace' . $this->colorspace;
         }
         if (!is_null($this->trimColor) || !is_null($this->trimFuzz)) {
-            $str .= 'trim' . strval($this->trimColor . 'x' . $this->trimFuzz);
+            $str .= 'trim';
+            if (!empty($this->trimColor)) {
+                $str .= (string) $this->trimColor;
+            }
+            if (!empty($this->trimFuzz)) {
+                $str .= 'x' . (string) $this->trimFuzz;
+            }
         }
         if ($this->stripColorProfiles) {
             $str .= 'strip';
         }
+
         return $str;
     }
 }

--- a/test/CommandTest.php
+++ b/test/CommandTest.php
@@ -98,39 +98,66 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($command->canvasHeight());
     }
 
-    public function testFullTrimMod()
+    /**
+     * @param string $strCommand
+     * @param string $color
+     * @param string $fuzz
+     * @dataProvider dpTestOnlyTrimColor
+     */
+    public function testTrim($strCommand, $color, $fuzz)
     {
-        $command = self::command('trimAABBCCx2');
-        $this->assertEquals('AABBCC', $command->trimColor());
-        $this->assertEquals('2', $command->trimFuzz());
+        $command = self::command($strCommand);
+        $this->assertEquals($color, $command->trimColor());
+        $this->assertEquals($fuzz, $command->trimFuzz());
+        $this->assertEquals($strCommand, (string) $command);
     }
 
-    public function testOnlyTrimColor()
+    public function dpTestOnlyTrimColor()
     {
-        $command = self::command('trimAABBCCx');
-        $this->assertEquals('AABBCC', $command->trimColor());
-        $this->assertEquals('', $command->trimFuzz());
-    }
-
-    public function testOnlyTrimFuzz()
-    {
-        $command = self::command('trimx10');
-        $this->assertEquals('', $command->trimColor());
-        $this->assertEquals('10', $command->trimFuzz());
-    }
-
-    public function testSimpleTrim()
-    {
-        $command = self::command('trimx');
-        $this->assertEquals('trimx', strval($command));
+        return [
+            [
+                'trimAABBCC',
+                'AABBCC',
+                ''
+            ],
+            [
+                'trimFFF',
+                'FFF',
+                ''
+            ],
+            [
+                'trimAABBCCx2',
+                'AABBCC',
+                '2'
+            ],
+            [
+                'trimFFFx50',
+                'FFF',
+                '50'
+            ],
+            [
+                'trimx10',
+                '',
+                '10'
+            ],
+            [
+                'trim',
+                '',
+                ''
+            ]
+        ];
     }
 
     public function testCanConstructSameUrlUrlWithAllParams()
     {
-        $this->assertEquals(
-            '200x100bgFF00FFcanvas300x200quality88colorspaceGraytrimAABBCCx1',
-            strval(self::command('200x100bgFF00FFcanvas300x200quality88colorspaceGraytrimAABBCCx1'))
-        );
+        $command = '200x100bgFF00FFcanvas300x200quality88colorspaceGraytrimAABBCCx1';
+        $this->assertEquals($command, strval(self::command($command)));
+    }
+
+    public function testCanConstructSameUrlUrlWithAllParamsAndSimpleTrim()
+    {
+        $command = '200x100bgFF00FFcanvas300x200quality88colorspaceGraytrim';
+        $this->assertEquals($command, strval(self::command($command)));
     }
 
 //--------------------------------------------------------------------------------------------------

--- a/test/CommandTest.php
+++ b/test/CommandTest.php
@@ -98,6 +98,13 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($command->canvasHeight());
     }
 
+    public function testOnlyTrimColor()
+    {
+        $command = self::command('trimAABBCCx');
+        $this->assertEquals('AABBCC', $command->trimColor());
+        $this->assertEquals('', $command->trimFuzz());
+    }
+
     /**
      * @param string $strCommand
      * @param string $color


### PR DESCRIPTION
Simple command `trim` did not work without using `x`, it made clients
generate `trimx` instead of `trim`